### PR TITLE
add styling to focus timer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
         "react": "^18.2.0",
+        "react-circular-progressbar": "^2.1.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.1.3",
         "react-router-dom": "^6.18.0"
@@ -3176,6 +3177,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-circular-progressbar": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.1.0.tgz",
+      "integrity": "sha512-xp4THTrod4aLpGy68FX/k1Q3nzrfHUjUe5v6FsdwXBl3YVMwgeXYQKDrku7n/D6qsJA9CuunarAboC2xCiKs1g==",
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.7",
     "react": "^18.2.0",
+    "react-circular-progressbar": "^2.1.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.18.0"

--- a/src/components/FocusTimer/FocusTimerDetailed.css
+++ b/src/components/FocusTimer/FocusTimerDetailed.css
@@ -13,3 +13,69 @@
   letter-spacing: 1.08px;
   line-height: normal;
 }
+
+.focus-detailed-reset-container {
+  width: 100%;
+  text-align: right;
+  padding: 0px 50px;
+  box-sizing: border-box;
+}
+
+.focus-detailed-reset-icon {
+  margin-left: auto;
+  width: 80px;
+  cursor: pointer;
+}
+
+.focus-detailed-reset-icon:hover {
+  transform: scale(1.05);
+}
+
+.focus-detailed-reset-icon:active {
+  transform: scale(0.95);
+}
+
+.focus-detailed-circular-progress-bar-wrapper {
+  width: 100%;
+}
+
+.focus-detailed-circular-progress-bar {
+  margin: 0 auto;
+  width: 400px;
+  height: 400px;
+  aspect-ratio: 1 / 1;
+  text-align: center;
+  border-radius: 100%;
+  box-shadow: -50px -50px 100px #272c5a, 50px 50px 100px #121530;
+  cursor: pointer;
+}
+
+.focus-detailed-circular-progress-bar:active {
+  transform: scale(0.98);
+}
+
+.focus-detailed-options button {
+  font-size: 36px;
+  border: 2px solid grey;
+  background-color: #083ca4;
+  /* background-color: white; */
+  color: grey;
+  padding: 14px 28px;
+}
+
+.focus-detailed-options {
+  margin-top: 100px;
+}
+
+.CircularProgressbar-path {
+  stroke: rgb(249, 95, 95);
+}
+.CircularProgressbar-trail {
+  stroke: #022569;
+}
+.CircularProgressbar-text {
+  fill: white;
+}
+.CircularProgressbar-background {
+  fill: green;
+}

--- a/src/components/FocusTimer/FocusTimerDetailed.jsx
+++ b/src/components/FocusTimer/FocusTimerDetailed.jsx
@@ -1,10 +1,15 @@
 import { useDispatch, useSelector } from 'react-redux';
+import {
+  CircularProgressbarWithChildren,
+  buildStyles,
+} from 'react-circular-progressbar';
 
 import {
   handlePauseFocusTimer,
   handleResetFocusTimer,
   handleStartFocusTimer,
 } from './FocusTimerDispatch';
+import { ResetIcon } from '../svgs/ResetIcon';
 import { millisToMinutesAndSeconds } from '../../helpers';
 import './FocusTimerDetailed.css';
 
@@ -16,34 +21,63 @@ export const FocusTimerDetailed = () => {
     state => state.settings.focusTimerLengthMS
   );
 
+  const percentage = (focusTimer.focusTimer / focusTimerLengthMS) * 100;
+
+  const handleClickTimer = () => {
+    if (!focusTimer.isFocusTimerRunning) {
+      handleStartFocusTimer(dispatch, focusTimer, focusTimerLengthMS);
+    } else {
+      handlePauseFocusTimer(dispatch);
+    }
+  };
+
+  const renderFocusTimerText = () => {
+    if (!focusTimer.isFocusTimerRunning) {
+      return 'S T A R T';
+    } else if (
+      focusTimer.isFocusTimerRunning &&
+      !focusTimer.isFocusTimerPaused
+    ) {
+      return 'P A U S E';
+    } else if (
+      focusTimer.isFocusTimerRunning &&
+      focusTimer.isFocusTimerPaused
+    ) {
+      return 'R E S U M E';
+    }
+  };
+
   return (
     <div className="focus-detailed-wrapper">
       <h2>Get Focused</h2>
-      {millisToMinutesAndSeconds(focusTimer.focusTimer)}
-      <div>
-        {!focusTimer.isFocusTimerRunning && (
-          <button
-            onClick={() =>
-              handleStartFocusTimer(dispatch, focusTimer, focusTimerLengthMS)
-            }
-          >
-            start timer
-          </button>
-        )}
-        {focusTimer.isFocusTimerRunning && (
-          <button onClick={() => handlePauseFocusTimer(dispatch)}>
-            {!focusTimer.isFocusTimerPaused ? 'pause' : 'unpause'} timer
-          </button>
-        )}
-        {focusTimer.isFocusTimerRunning && (
-          <button
-            onClick={() => handleResetFocusTimer(dispatch, focusTimerLengthMS)}
-          >
-            reset timer
-          </button>
-        )}
+      <div className="focus-detailed-reset-container">
+        <div
+          className="focus-detailed-reset-icon"
+          onClick={() => handleResetFocusTimer(dispatch, focusTimerLengthMS)}
+        >
+          <ResetIcon />
+        </div>
       </div>
-      <div># of focus timers: {focusTimer.focusTimerCount}</div>
+      <div className="focus-detailed-circular-progress-bar-wrapper">
+        <div
+          className="focus-detailed-circular-progress-bar"
+          onClick={() => handleClickTimer()}
+        >
+          <CircularProgressbarWithChildren
+            value={percentage}
+            styles={buildStyles({
+              // How long animation takes to go from one percentage to another, in seconds
+              pathTransitionDuration: 0.5,
+            })}
+          >
+            <h1>{millisToMinutesAndSeconds(focusTimer.focusTimer)}</h1>
+            <h6>{renderFocusTimerText()}</h6>
+          </CircularProgressbarWithChildren>
+        </div>
+      </div>
+      <div className="focus-detailed-options">
+        <div>Focus timer done today: {focusTimer.focusTimerCount}</div>
+      </div>
     </div>
   );
 };

--- a/src/components/FocusTimer/FocusTimerDispatch.js
+++ b/src/components/FocusTimer/FocusTimerDispatch.js
@@ -26,6 +26,6 @@ export const handlePauseFocusTimer = dispatch => {
 };
 
 export const handleResetFocusTimer = (dispatch, focusTimerLengthMS) => {
-  dispatch(setFocusTimer({ focusTimer: focusTimerLengthMS }));
   dispatch(resetFocusTimer({}));
+  dispatch(setFocusTimer({ focusTimer: focusTimerLengthMS }));
 };

--- a/src/components/svgs/ResetIcon.jsx
+++ b/src/components/svgs/ResetIcon.jsx
@@ -1,0 +1,23 @@
+export const ResetIcon = () => {
+  return (
+    <svg
+      width="60px"
+      height="60px"
+      viewBox="0 0 21 21"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fillRule="evenodd"
+        stroke="white"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        transform="matrix(0 1 1 0 2.5 2.5)"
+      >
+        <path d="m3.98652376 1.07807068c-2.38377179 1.38514556-3.98652376 3.96636605-3.98652376 6.92192932 0 4.418278 3.581722 8 8 8s8-3.581722 8-8-3.581722-8-8-8" />
+
+        <path d="m4 1v4h-4" transform="matrix(1 0 0 -1 0 6)" />
+      </g>
+    </svg>
+  );
+};


### PR DESCRIPTION
This PR adds styling to the focus timer. This can still be much improved, particularly the colors, but we can start with this.

![timer](https://github.com/themisterkai/DevWellnessHub/assets/9663970/fbccf513-c9c2-4f20-8424-33e156a4a361)
