### PR TITLE
fix resizing issue with focus and breathe timers

### DIFF
--- a/src/components/FocusTimer/FocusTimerDetailed.css
+++ b/src/components/FocusTimer/FocusTimerDetailed.css
@@ -95,6 +95,11 @@
   .focus-done-day {
     font-size: 2vmin;
   }
+
+  .focus-detailed-circular-progress-bar {
+    width: 25vw;
+    height: 25vw;
+  }
 }
 
 /* Media query for larger screens (e.g., desktops) */


### PR DESCRIPTION
![resize](https://github.com/themisterkai/DevWellnessHub/assets/9663970/b090ce61-5dd0-406a-ba67-fbf78a9dace1)
