### PR TITLE
fix: resolve 7 bugs, clean up imports, and update package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-vite-boilerplate",
+  "name": "dev-wellness",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-vite-boilerplate",
+      "name": "dev-wellness",
       "version": "0.0.0",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-vite-boilerplate",
+  "name": "dev-wellness",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/MasterStyle.css
+++ b/src/MasterStyle.css
@@ -99,7 +99,7 @@ body {
 
 .app-button:active {
   background-color: var(--tertiary-bg-color);
-  border-color: var(-primary-accent-color);
+  border-color: var(--primary-accent-color);
   color: var(--primary-text-color);
 }
 

--- a/src/components/BreatheTimer/BreatheTimer.jsx
+++ b/src/components/BreatheTimer/BreatheTimer.jsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux/es/hooks/useSelector';
+import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { BreathCircle } from '../../assets/SVGElements';

--- a/src/components/FocusTimer/FocusTimer.jsx
+++ b/src/components/FocusTimer/FocusTimer.jsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux/es/hooks/useSelector';
+import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { FocusCircle } from '../../assets/SVGElements';

--- a/src/components/HabitTracker/HabitTracker.jsx
+++ b/src/components/HabitTracker/HabitTracker.jsx
@@ -1,7 +1,7 @@
 // This is the component shown in the Dashboard
 // Conditionally show either expanded or unexpanded depending the screen size
 import { HabitCircle } from '../../assets/SVGElements';
-import { useSelector } from 'react-redux/es/hooks/useSelector';
+import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import './HabitTracker.css';
 

--- a/src/components/HistoricalCal/HistoricalCal.css
+++ b/src/components/HistoricalCal/HistoricalCal.css
@@ -1,6 +1,6 @@
 .historical-wrapper{
     width: 20vw; 
     height: 20vh;
-    background-color: #4a4d53;
+    background-color: var(--tertiary-bg-color);
     border-radius: 10px;
 }

--- a/src/components/HistoricalCal/HistoricalCalDetailed.css
+++ b/src/components/HistoricalCal/HistoricalCalDetailed.css
@@ -2,6 +2,6 @@
 .historical-cal-wrapper {
     width: 30vw; 
     height: 95vh;
-    background-color:#1C1D1F;
+    background-color: var(--secondary-bg-color);
     border-radius: 20px;
   }

--- a/src/components/MoodTracker/MoodTracker.jsx
+++ b/src/components/MoodTracker/MoodTracker.jsx
@@ -1,5 +1,5 @@
 import { MoodDown, MoodStableLine, MoodUp } from "../../assets/SVGElements";
-import { useSelector } from "react-redux/es/hooks/useSelector";
+import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import "./MoodTracker.css"
 // This is the component shown in the Dashboard

--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -30,7 +30,7 @@
 }
 
 /* Media query for smaller screens (e.g., mobile devices) */
-@media only screen and (max-width: 76px) {
+@media only screen and (max-width: 767px) {
   .app-wrapper {
     gap: 2vmin 4vmin;
     width: 60vmin;

--- a/src/reducers/breatheTimer.js
+++ b/src/reducers/breatheTimer.js
@@ -23,7 +23,7 @@ export const breatheTimer = createSlice({
     resetBreatheTimer: state => {
       state.isBreatheTimerRunning = false;
       state.isBreatheTimerPaused = false;
-      state.focusTimer = 0;
+      state.breatheTimer = 0;
     },
 
     endBreatheTimer: state => {

--- a/src/reducers/historical.js
+++ b/src/reducers/historical.js
@@ -11,15 +11,25 @@ export const historical = createSlice({
   initialState,
   reducers: {
     loadHistoricalData: state => {
-      const historicalData = { ...localStorage };
-      // delete settings data
-      delete historicalData.settings;
-      // delete data for the current date
-      delete historicalData[getCurrentDate()];
-      state.historicalData = { ...historicalData };
+      // Only load date-keyed entries (YYYY-MM-DD format) from localStorage
+      const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+      const currentDate = getCurrentDate();
+      const historicalData = {};
+
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (datePattern.test(key) && key !== currentDate) {
+          try {
+            historicalData[key] = JSON.parse(localStorage.getItem(key));
+          } catch {
+            // skip malformed entries
+          }
+        }
+      }
+
+      state.historicalData = historicalData;
     },
   },
 });
 
-export const { loadHistoricalData, setEnergyLevel, setOverwhelmedLevel } =
-  historical.actions;
+export const { loadHistoricalData } = historical.actions;


### PR DESCRIPTION
## Summary

Went through the full codebase and found a handful of bugs and cleanup opportunities. All fixes are minimal and surgical — no refactoring, no dependency changes, just corrections.

## Bugs Fixed

### 1. Breathe timer resets wrong state property
**File:** `src/reducers/breatheTimer.js` line 26
**Before:** `state.focusTimer = 0` — resets the focus timer value when breathe timer is reset
**After:** `state.breatheTimer = 0`

### 2. Historical data loads entire localStorage
**File:** `src/reducers/historical.js`
**Before:** `{ ...localStorage }` spreads every key in localStorage, including data from other apps/extensions. Then manually deletes `settings` — but misses any other non-app keys.
**After:** Only loads entries matching the `YYYY-MM-DD` date format with `JSON.parse` error handling.

### 3. Dead exports in historical slice
**File:** `src/reducers/historical.js` line 24
**Before:** Exports `setEnergyLevel, setOverwhelmedLevel` which don't exist in this slice (copy-paste from mood.js).
**After:** Only exports `loadHistoricalData`.

### 4. Dashboard mobile media query typo
**File:** `src/pages/Dashboard.css` line 33
**Before:** `@media only screen and (max-width: 76px)` — never triggers (76px is ~1cm)
**After:** `@media only screen and (max-width: 767px)`

### 5. CSS variable typo in MasterStyle
**File:** `src/MasterStyle.css` line 102
**Before:** `var(-primary-accent-color)` — missing double-dash, CSS silently ignores it
**After:** `var(--primary-accent-color)`

### 6–7. Hardcoded colors in HistoricalCal components
**Files:** `HistoricalCal.css`, `HistoricalCalDetailed.css`
**Before:** Hardcoded hex values (`#4a4d53`, `#1C1D1F`) that break when theme changes
**After:** `var(--tertiary-bg-color)`, `var(--secondary-bg-color)`

## Cleanup

- **Import paths:** 4 components imported `useSelector` from `react-redux/es/hooks/useSelector` (internal path). Replaced with the public API `react-redux`. The internal path works today but could break on library updates.
- **Package name:** Updated from `react-vite-boilerplate` to `dev-wellness`.

## Testing

- `vite build` passes clean ✓
- All changes are isolated fixes — no refactoring or behavioral changes beyond the bug corrections.